### PR TITLE
Remove old link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Statsd-librato
 
-[https://github.com/jcoene/statsd-librato](https://github.com/jcoene/statsd-librato) in a container.
-
 A typical systemd unit file, deployed via Ansible, is below.
 
 ```


### PR DESCRIPTION
The link is to a Go version of statsd. This uses node.
